### PR TITLE
addition for python one-liner

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
                 "scopeName": "source.gdb",
                 "path": "./syntaxes/gdb.tmLanguage.json",
                 "embeddedLanguages": {
-                    "meta.embedded.python.gdb": "python"
+                    "meta.embedded.python.gdb": "python",
+                    "meta.line.python.gdb": "python"
                 }
             }
         ]

--- a/syntaxes/gdb.tmLanguage.json
+++ b/syntaxes/gdb.tmLanguage.json
@@ -387,6 +387,19 @@
 							"include": "source.python"
 						}
 					]
+				},
+				{
+					"name": "meta.line.python.gdb",
+					"begin": "^\\s*(py(?:thon)?)\\s+",
+					"beginCaptures": {
+						"1": { "name": "keyword.control.command.gdb" }
+					},
+					"end": "\\s*$",
+					"patterns": [
+						{
+							"include": "source.python"
+						}
+					]
 				}
 			]
 		},


### PR DESCRIPTION
fat warning: this is completely untested and I'm in no way knowledgable in tmlanguage.... but I wanted to try.

already working before:

```
py
    some.value = int(some.validate(some.value))
end
```

now _possibly_ working, too:


```
py some.value = int(some.validate(some.value))
```