### PR TITLE
drop "uncommon" language aliases

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "contributes": {
         "languages": [{
             "id": "gdb",
-            "aliases": ["syntax", "gdb", "color-higlight"],
             "extensions": [".gdb",".gdbinit"],
             "configuration": "./language-configuration.json"
         }],


### PR DESCRIPTION
this is definitely "highly intrusive", but please consider this in any case

After this the language shown should also be "gdb" (it currently shows as "syntax"); as an alternative one _may_ could use the alias "GDB command file" (but that's quite long) or "GDB".